### PR TITLE
Add `lanip` type

### DIFF
--- a/docs/buildin.md
+++ b/docs/buildin.md
@@ -100,6 +100,22 @@ Activate *fqn* with ```fqn: true``` to show the hostname fully qualified with th
 ```
 
 
+## LAN IP
+
+The type **lanip** shows the current IP address of the sepcified interface.
+
+### Interface
+
+Specify *interface* to display the IP address of the desired interface. If this property is not specified, then an error is shown.
+
+### Example
+
+``` yaml
+  - name: example
+    type: lanip
+    interface: wlan0
+```
+
 ## Load Average
 
 The type **loadavg** shows the load average for the past minute in the default [unix format](https://en.wikipedia.org/wiki/Load_(computing)).

--- a/src/buildin/index.js
+++ b/src/buildin/index.js
@@ -6,6 +6,7 @@ import command from './command';
 import date from './date';
 import diskfree from './diskfree';
 import hostname from './hostname';
+import lanip from './lanip';
 import loadavg from './loadavg';
 import memory from './memory';
 import text from './text';
@@ -20,6 +21,7 @@ export default {
     date,
     diskfree,
     hostname,
+    lanip,
     loadavg,
     memory,
     text,

--- a/src/buildin/lanip.js
+++ b/src/buildin/lanip.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/** @module builtin/lanip */
+
+import { EventEmitter } from 'events';
+import { networkInterfaces } from 'os';
+
+export default class LanIP extends EventEmitter {
+    /**
+     * @param {Object} options - block configuration from config file
+     * @param {Object} output - block output for i3bar
+     */
+    constructor(options, output) {
+        super();
+        options = options || {};
+        this.output = output || {};
+
+        this.interface = options.interface;
+    }
+
+    /**
+     * update the block's output with the IP of the specified interface
+     */
+    update() {
+        const output = this.buildText();
+
+        output.full_text = output.text;
+        output.short_text = output.text;
+
+        this.output = output;
+        this.emit('updated', this, output);
+
+        return output;
+    }
+
+    buildText() {
+        const output = {};
+
+        const interfaces = networkInterfaces();
+        const networks = interfaces[this.interface];
+
+        if ( ! networks ) {
+            output.text = `interface not found: '${this.interface}'`;
+            return;
+        }
+
+        if ( networks.length < 1 ) {
+            output.text = `No IP`;
+            return;
+        }
+
+        output.text = networks[0].address;
+
+        return output;
+    }
+}


### PR DESCRIPTION
This PR adds a block type called `lanip` to display the local IP address of the desired network interface.